### PR TITLE
fix demotion of players when someone changes color

### DIFF
--- a/TTSLUA/global.ttslua
+++ b/TTSLUA/global.ttslua
@@ -179,8 +179,8 @@ end
 function promotePlayers()
     local colors={"Red", "Blue", "Orange", "Yellow", "Purple", "Teal"}
     for i, color in ipairs(colors) do
-        if Player[color].seated and  Player[color].host == false then
-             Player[color].promote(true)
+        if Player[color].seated and  Player[color].host == false and not Player[color].promoted then
+            Player[color].promote()
         end
     end
 end


### PR DESCRIPTION
The promote API (https://api.tabletopsimulator.com/player/instance/#promote) does not take an argument, and just toggles whether a player is promoted. 

We therefor must check if a player is already promoted before trying to promote them.