### PR TITLE
Colored Sustained Hits

### DIFF
--- a/TTSLUA/diceTable.ttslua
+++ b/TTSLUA/diceTable.ttslua
@@ -458,19 +458,17 @@ function lethalsAndOrSustainedAction(player, sustained, lethals, alt)
     local z_delta = (whichDiceMat == "Red") and 3.3 or -3.3
 
     if #crits > 0 then
-        if sustained then 
-            for _, die in ipairs(crits) do
-                die.clone()
+        for _, die in ipairs(crits) do
+            pos = die.getPosition()
+            if sustained then
+                die.clone({position = pos, snap_to_grid = false})
             end
-            printToColor("Generated " .. #crits .. " sustained hits.", player, "Yellow")
-        end
-        if lethals then
-            for _, die in ipairs(crits) do
-                pos = die.getPosition()
+            if lethals then
                 die.setPositionSmooth({x=pos.x, y=pos.y, z=pos.z + z_delta}, false, true)
             end
-            printToColor("Moved " .. #crits .. " lethals off the mat.", player, "Yellow")
         end
+        if sustained then printToColor("Cloned " .. #crits .. " sustained.", player, "Yellow") end
+        if lethals then printToColor("Moved " .. #crits .. " lethals off the mat.", player, "Yellow") end
     else
         printToColor("No critical hits.", player, "Yellow")
     end

--- a/TTSLUA/diceTable.ttslua
+++ b/TTSLUA/diceTable.ttslua
@@ -458,16 +458,18 @@ function lethalsAndOrSustainedAction(player, sustained, lethals, alt)
     local z_delta = (whichDiceMat == "Red") and 3.3 or -3.3
 
     if #crits > 0 then
+        if sustained then 
+            for _, die in ipairs(crits) do
+                die.clone()
+            end
+            printToColor("Generated " .. #crits .. " sustained hits.", player, "Yellow")
+        end
         if lethals then
             for _, die in ipairs(crits) do
                 pos = die.getPosition()
                 die.setPositionSmooth({x=pos.x, y=pos.y, z=pos.z + z_delta}, false, true)
             end
             printToColor("Moved " .. #crits .. " lethals off the mat.", player, "Yellow")
-        end
-        if sustained then
-            spawnDice(#crits, player)
-            printToColor("Generated " .. #crits .. " sustained hits.", player, "Yellow")
         end
     else
         printToColor("No critical hits.", player, "Yellow")


### PR DESCRIPTION
Currently, the "Sustained hits" button takes the number of critical hits and generates this many new dice with the currently selected new dice color.

So, when we have several dice colors, the added dice don't match the original dice.

<img width="763" height="511" alt="Capture d&#39;écran 2026-02-02 154539" src="https://github.com/user-attachments/assets/f77eecc7-14a9-4821-913e-0c753720f01e" />

To enhance this feature in this specific scenario, this PR's approach is to clone the critical dice when generating sustained hits, so that we keep the same color repartition.

This causes a slight change in how the sustained hits are added : they're now directly spawned above the previous dice.

<img width="1319" height="655" alt="image" src="https://github.com/user-attachments/assets/e1ac3afc-03e5-49c7-9727-541bc986a7b0" />

  